### PR TITLE
Feat: Add delete functionality for bill items

### DIFF
--- a/src/app/mobile/page.tsx
+++ b/src/app/mobile/page.tsx
@@ -16,7 +16,7 @@ import {
   CarouselPrevious,
   type CarouselApi,
 } from "@/components/ui/carousel";
-import { Trash2 } from 'lucide-react'; // Added Trash2
+import { Trash2 } from 'lucide-react';
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -81,7 +81,7 @@ export default function Form() {
     tax,
     setTax,
     setTable,
-    deleteItem // Added deleteItem
+    deleteItem
   } = context;
 
 
@@ -149,9 +149,8 @@ export default function Form() {
           {items.map((item, i) => (
             <TableRow
               key={i}
-              // onClick logic moved to individual cells if row click is still desired for selection
             >
-              <TableCell onClick={() => toggleBuyer(i, people[current - 1])}> {/* Moved onClick */}
+              <TableCell onClick={() => toggleBuyer(i, people[current - 1])}>
                 <div className="flex">
                   <div
                     className={`bg-black mr-1 w-1 ${item.buyers.includes(people[current - 1]) ? "" : "hidden"}`}
@@ -185,7 +184,7 @@ export default function Form() {
                   </div>
                 </div>
               </TableCell>
-              <TableCell className="text-right" onClick={() => toggleBuyer(i, people[current - 1])}> {/* Moved onClick */}
+              <TableCell className="text-right" onClick={() => toggleBuyer(i, people[current - 1])}>
                 ${item.price.toFixed(2)}
               </TableCell>
               <TableCell className="text-right">
@@ -193,7 +192,7 @@ export default function Form() {
                   variant="destructive"
                   size="icon"
                   onClick={(e) => {
-                    e.stopPropagation(); // Prevent row click if any
+                    e.stopPropagation();
                     deleteItem(i);
                   }}
                 >
@@ -203,7 +202,7 @@ export default function Form() {
             </TableRow>
           ))}
           <TableRow>
-            <TableCell className="font-bold" colSpan={3}> {/* Adjusted colSpan */}
+            <TableCell className="font-bold" colSpan={3}>
               <AlertDialog open={itemFormOpen}>
                 <Button
                   className="w-full"
@@ -266,13 +265,13 @@ export default function Form() {
           {items.length > 0 ? (
             <>
               <TableRow>
-                <TableCell className="font-bold" colSpan={2}>Subtotal</TableCell> {/* Adjusted colSpan */}
+                <TableCell className="font-bold" colSpan={2}>Subtotal</TableCell>
                 <TableCell className="text-right font-bold">
                   ${getSubtotal(items).toFixed(2)}
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-bold" colSpan={2}>Tax</TableCell> {/* Adjusted colSpan */}
+                <TableCell className="font-bold" colSpan={2}>Tax</TableCell>
                 <TableCell className="text-right font-bold">
                   <div className="flex flex-col">
                     <span>${tax.toFixed(2)}</span>
@@ -287,13 +286,13 @@ export default function Form() {
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-bold" colSpan={2}>Tip</TableCell> {/* Adjusted colSpan */}
+                <TableCell className="font-bold" colSpan={2}>Tip</TableCell>
                 <TableCell className="text-right font-bold">
                   ${tip.toFixed(2)}
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-bold" colSpan={2}>Total</TableCell> {/* Adjusted colSpan */}
+                <TableCell className="font-bold" colSpan={2}>Total</TableCell>
                 <TableCell className="text-right font-bold">
                   ${getTotal(tip, tax, items)}
                 </TableCell>

--- a/src/app/mobile/page.tsx
+++ b/src/app/mobile/page.tsx
@@ -16,6 +16,7 @@ import {
   CarouselPrevious,
   type CarouselApi,
 } from "@/components/ui/carousel";
+import { Trash2 } from 'lucide-react'; // Added Trash2
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -79,7 +80,8 @@ export default function Form() {
     setTip,
     tax,
     setTax,
-    setTable
+    setTable,
+    deleteItem // Added deleteItem
   } = context;
 
 
@@ -147,11 +149,9 @@ export default function Form() {
           {items.map((item, i) => (
             <TableRow
               key={i}
-              onClick={() => {
-                toggleBuyer(i, people[current - 1]);
-              }}
+              // onClick logic moved to individual cells if row click is still desired for selection
             >
-              <TableCell>
+              <TableCell onClick={() => toggleBuyer(i, people[current - 1])}> {/* Moved onClick */}
                 <div className="flex">
                   <div
                     className={`bg-black mr-1 w-1 ${item.buyers.includes(people[current - 1]) ? "" : "hidden"}`}
@@ -185,13 +185,25 @@ export default function Form() {
                   </div>
                 </div>
               </TableCell>
-              <TableCell className="text-right">
+              <TableCell className="text-right" onClick={() => toggleBuyer(i, people[current - 1])}> {/* Moved onClick */}
                 ${item.price.toFixed(2)}
+              </TableCell>
+              <TableCell className="text-right">
+                <Button
+                  variant="destructive"
+                  size="icon"
+                  onClick={(e) => {
+                    e.stopPropagation(); // Prevent row click if any
+                    deleteItem(i);
+                  }}
+                >
+                  <Trash2 />
+                </Button>
               </TableCell>
             </TableRow>
           ))}
           <TableRow>
-            <TableCell className="font-bold" colSpan={2}>
+            <TableCell className="font-bold" colSpan={3}> {/* Adjusted colSpan */}
               <AlertDialog open={itemFormOpen}>
                 <Button
                   className="w-full"
@@ -254,13 +266,13 @@ export default function Form() {
           {items.length > 0 ? (
             <>
               <TableRow>
-                <TableCell className="font-bold">Subtotal</TableCell>
+                <TableCell className="font-bold" colSpan={2}>Subtotal</TableCell> {/* Adjusted colSpan */}
                 <TableCell className="text-right font-bold">
                   ${getSubtotal(items).toFixed(2)}
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-bold">Tax</TableCell>
+                <TableCell className="font-bold" colSpan={2}>Tax</TableCell> {/* Adjusted colSpan */}
                 <TableCell className="text-right font-bold">
                   <div className="flex flex-col">
                     <span>${tax.toFixed(2)}</span>
@@ -275,13 +287,13 @@ export default function Form() {
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-bold">Tip</TableCell>
+                <TableCell className="font-bold" colSpan={2}>Tip</TableCell> {/* Adjusted colSpan */}
                 <TableCell className="text-right font-bold">
                   ${tip.toFixed(2)}
                 </TableCell>
               </TableRow>
               <TableRow>
-                <TableCell className="font-bold">Total</TableCell>
+                <TableCell className="font-bold" colSpan={2}>Total</TableCell> {/* Adjusted colSpan */}
                 <TableCell className="text-right font-bold">
                   ${getTotal(tip, tax, items)}
                 </TableCell>

--- a/src/components/BillProvider.tsx
+++ b/src/components/BillProvider.tsx
@@ -28,6 +28,7 @@ export interface BillContextType {
   setTip: React.Dispatch<React.SetStateAction<number>>;
   tax: number;
   setTax: React.Dispatch<React.SetStateAction<number>>;
+  deleteItem: (index: number) => void;
 }
 
 // Create the context with a default value
@@ -48,6 +49,10 @@ export const BillProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
   ]);
   const [tip, setTip] = useState<number>(0);
   const [tax, setTax] = useState<number>(0);
+
+  const deleteItem = (index: number) => {
+    setItems(prevItems => prevItems.filter((_, i) => i !== index));
+  };
 
   const value: BillContextType = {
     items,
@@ -72,6 +77,7 @@ export const BillProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     setTip,
     tax,
     setTax,
+    deleteItem,
   };
 
   return (


### PR DESCRIPTION
This commit introduces the ability for you to delete items from the bill in the mobile UI.

Changes include:

1. `src/components/BillProvider.tsx`:
    - Added a `deleteItem(index: number)` function to the `BillContext`.
    - This function removes the item at the specified index from the `items` array and updates the state.
    - Exposed `deleteItem` through the context provider.

2. `src/app/mobile/page.tsx`:
    - Imported the `Trash2` icon from `lucide-react`.
    - Added a new `TableCell` to each item row in the items table.
    - This cell contains a "destructive" variant `Button` with the `Trash2` icon.
    - The button's `onClick` handler calls the `deleteItem` function from the context, correctly removing the item.
    - `event.stopPropagation()` is used in the delete button's `onClick` to prevent interference with the row's `toggleBuyer` click handler.
    - Adjusted `colSpan` attributes for the "Add Item" button row and summary rows (Subtotal, Tax, Tip, Total) to ensure consistent table layout after adding the new column for delete buttons.