### PR TITLE
Fix/receipt tax parsing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -61,7 +61,7 @@ export default function Form() {
     tax,
     table,
     setTable,
-    deleteItem // Added deleteItem
+    deleteItem
   } = context;
   // const [items, setItems] = useState<Item[]>([]);
   // const [people, setPeople] = useState<string[]>([]);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -60,7 +60,8 @@ export default function Form() {
     tip,
     tax,
     table,
-    setTable
+    setTable,
+    deleteItem // Added deleteItem
   } = context;
   // const [items, setItems] = useState<Item[]>([]);
   // const [people, setPeople] = useState<string[]>([]);
@@ -299,7 +300,20 @@ export default function Form() {
               />
             </div>
           </div>
-          <Button onClick={handleSaveEdit}>Save Changes</Button>
+          <div className="flex justify-end gap-2">
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (editingItemIndex !== null) {
+                  deleteItem(editingItemIndex);
+                  setEditingItemIndex(null); // Close the dialog
+                }
+              }}
+            >
+              Delete
+            </Button>
+            <Button onClick={handleSaveEdit}>Save Changes</Button>
+          </div>
         </DialogContent>
       </Dialog>
       <CardFooter className="flex flex-col w-full">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -306,7 +306,7 @@ export default function Form() {
               onClick={() => {
                 if (editingItemIndex !== null) {
                   deleteItem(editingItemIndex);
-                  setEditingItemIndex(null); // Close the dialog
+                  setEditingItemIndex(null);
                 }
               }}
             >

--- a/src/components/PhotoUpload.tsx
+++ b/src/components/PhotoUpload.tsx
@@ -13,7 +13,7 @@ const PhotoUpload: React.FC = () => {
   if (!context) {
     throw new Error('useBill must be used within a BillProvider');
   }
-  const { setItems, setTax, setTip } = context; // Added setTip
+  const { setItems, setTax, setTip } = context;
 
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [isLoading, setIsLoading] = useState(false);


### PR DESCRIPTION
This commit enhances the item editing functionality in the non-mobile UI (`src/app/page.tsx`) by adding a 'Delete' button to the 'Edit Item' dialog.

When you click on an item name to edit it, the dialog that appears now includes:
- The existing fields for editing item name and price.
- The existing 'Save Changes' button.
- A new 'Delete' button with a 'destructive' variant.

Clicking the 'Delete' button will:
- Remove the currently editing item from the bill using the `deleteItem` function from `BillContext`.
- Close the 'Edit Item' dialog.

The 'Save Changes' and 'Delete' buttons are grouped together at the bottom of the dialog for a clean layout.